### PR TITLE
Fix TU2C preset readback from extended status

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -2080,8 +2080,10 @@ void ToshibaAbClimate::process_received_data_tu2c_(const struct DataFrame *frame
     }
     tcc_state.preheating = (payload[STATUS_DATA_FLAGS_BYTE] & 0b00000010) >> 1;
     tcc_state.filter_alert = (payload[STATUS_DATA_FLAGS_BYTE] & 0b10000000) >> 7;
-    if (payload_available > TU2C_STATUS_DATA_PRESET_BYTE) {
-      tcc_state.preset = payload[TU2C_STATUS_DATA_PRESET_BYTE];
+    const uint8_t preset_byte =
+        is_extended_status_frame ? TU2C_EXTENDED_STATUS_DATA_PRESET_BYTE : TU2C_STATUS_DATA_PRESET_BYTE;
+    if (payload_available > preset_byte) {
+      tcc_state.preset = payload[preset_byte];
     }
 
     ESP_LOGD(

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -63,7 +63,10 @@ const uint8_t STATUS_DATA_FAN_SHIFT_BITS = 5;
 const uint8_t STATUS_DATA_VENT_MASK = 0b00000100;
 const uint8_t STATUS_DATA_VENT_SHIFT_BITS = 2;
 const uint8_t STATUS_DATA_TARGET_TEMP_BYTE = 6;
+// TU2C's regular and extended status payloads place the preset at different
+// offsets. Extended status inserts room-temperature/status fields before it.
 const uint8_t TU2C_STATUS_DATA_PRESET_BYTE = 8;
+const uint8_t TU2C_EXTENDED_STATUS_DATA_PRESET_BYTE = 11;
 
 const uint8_t COMMAND_MODE_READ = 0x08;
 const uint8_t COMMAND_MODE_WRITE = 0x80;


### PR DESCRIPTION
### Motivation

- Home Assistant was losing the selected TU2C preset after a successful change because periodic TU2C extended status broadcasts placed the preset in a different payload offset and the code read the wrong byte. 

### Description

- Add `TU2C_EXTENDED_STATUS_DATA_PRESET_BYTE` and document that regular and extended TU2C status payloads place the preset at different offsets in `components/toshiba_ab/toshiba_ab.h`. 
- Update `process_received_data_tu2c_` in `components/toshiba_ab/toshiba_ab.cpp` to choose the preset byte based on `is_extended_status_frame` and keep the existing payload bounds check before reading the preset. 

### Testing

- Ran a small regression script that decodes the regular and extended TU2C frames from issue #170 and verified both frames resolve to preset value `0x03` (succeeded).
- Ran code checks and formatting with `git diff --check`, `./format.sh` and `clang-format` to ensure no style errors (succeeded).
- Attempted to run a firmware build but `esphome` / `platformio` were not available in the environment, so a full build/test on hardware was not executed (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91544bf818832f9c943190780fd4cc)