### PR TITLE
DHW Switch

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -75,6 +75,7 @@ CONF_BACKUP_HEATER_HOURS = "backup_heater_hours"
 CONF_DEMAND = "demand"
 CONF_DEMAND_ENABLED = "demand_enabled"
 CONF_ZONE1_SWITCH = "zone1_switch"
+CONF_DHW_SWITCH = "dhw_switch"
 CONF_DHW_BOOST = "dhw_boost"
 CONF_ANTIBACTERIA = "antibacteria"
 CONF_ZONE1_WATER_TEMPERATURE = "zone1_water_temperature"
@@ -112,6 +113,9 @@ ToshibaAbReadOnlySwitch = toshiba_ab_ns.class_(
 )
 ToshibaAbEstiaZone1Switch = toshiba_ab_ns.class_(
     "ToshibaAbEstiaZone1Switch", switch.Switch, cg.Component
+)
+ToshibaAbEstiaDhwSwitch = toshiba_ab_ns.class_(
+    "ToshibaAbEstiaDhwSwitch", switch.Switch, cg.Component
 )
 ToshibaAbEstiaDhwBoostSwitch = toshiba_ab_ns.class_(
     "ToshibaAbEstiaDhwBoostSwitch", switch.Switch, cg.Component
@@ -235,6 +239,16 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
                 cv.Schema(
                     {
                         cv.GenerateID(): cv.declare_id(ToshibaAbEstiaZone1Switch),
+                    }
+                )
+            ),
+            key=CONF_NAME,
+        ),
+        cv.Optional(CONF_DHW_SWITCH): cv.maybe_simple_value(
+            switch._SWITCH_SCHEMA.extend(
+                cv.Schema(
+                    {
+                        cv.GenerateID(): cv.declare_id(ToshibaAbEstiaDhwSwitch),
                     }
                 )
             ),
@@ -530,6 +544,9 @@ async def to_code(config):
     if CONF_ZONE1_SWITCH in config:
         sw = await switch.new_switch(config[CONF_ZONE1_SWITCH], var)
         cg.add(var.set_zone1_switch(sw))
+    if CONF_DHW_SWITCH in config:
+        sw = await switch.new_switch(config[CONF_DHW_SWITCH], var)
+        cg.add(var.set_dhw_switch(sw))
     if CONF_DHW_BOOST in config:
         sw = await switch.new_switch(config[CONF_DHW_BOOST], var)
         cg.add(var.set_dhw_boost_switch(sw))

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -2335,8 +2335,12 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
       float outdoor_temp = frame->raw[14] / 2.0f - 16.0f;
 
       bool power_on = (flags & 0x01) != 0;
+      bool dhw_active = (flags & 0x02) != 0;
       bool is_cooling = (flags & 0x20) != 0;
       bool is_heating = (flags & 0x40) != 0;
+      if (this->dhw_switch_ != nullptr) {
+        this->dhw_switch_->publish_state(dhw_active);
+      }
 
       ESP_LOGV(TAG, "Status: power=%s flags=0x%02X %s current=%.1f°C setpoint=%.1f°C outdoor=%.1f°C",
                power_on ? "ON" : "OFF", flags,
@@ -2432,9 +2436,14 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
     if (frame_type == 0x1C && frame_len >= 15 && frame->raw[7] == 0x03 && frame->raw[8] == 0xC6) {
       uint8_t flags = frame->raw[9];
       bool power_on = (flags & 0x01) != 0;
+      bool dhw_active = (flags & 0x02) != 0;
       bool is_cooling = (flags & 0x20) != 0;
       bool is_heating = (flags & 0x40) != 0;
       float setpoint = frame->raw[13] / 2.0f - 16.0f;
+
+      if (this->dhw_switch_ != nullptr) {
+        this->dhw_switch_->publish_state(dhw_active);
+      }
 
       climate::ClimateMode new_mode;
       if (!power_on) {
@@ -3423,6 +3432,43 @@ void ToshibaAbClimate::send_estia_power(bool on) {
   this->send_estia_tracked_(frame, sizeof(frame), 0x0041);  // ACK: 00:A1:00:41
 }
 
+void ToshibaAbClimate::send_estia_dhw(bool on) {
+  if (this->read_only_) {
+    ESP_LOGW(TAG, "Read-only mode: not sending Estia DHW command");
+    return;
+  }
+
+  uint16_t src = this->estia_source_address_;
+  // DHW production on/off shares the same dtype (00:41) as system power, but
+  // uses distinct command bytes (2C=on/28=off) rather than power's 23=on/22=off.
+  // Confirmed by capturing the physical wired remote's own frames:
+  //   TX: 11:08:00:00:40:08:00:00:41:2C:CRC  -> ACK 00:A1:00:41, status flags gain bit 0x02
+  //   TX: 11:08:00:00:40:08:00:00:41:28:CRC  -> ACK 00:A1:00:41, status flags lose bit 0x02
+  uint8_t dhw_cmd = on ? 0x2C : 0x28;
+
+  uint8_t frame[] = {
+    0xA0, 0x00,                         // prefix
+    0x11,                               // type: command
+    0x08,                               // length: 8
+    0x00,                               // fixed
+    (uint8_t)(src >> 8), (uint8_t)(src & 0xFF),  // source
+    0x08, 0x00,                         // dest: master
+    0x00, 0x41,                         // dtype: power/DHW control channel
+    dhw_cmd,                            // 0x2C=DHW ON, 0x28=DHW OFF
+    0x00, 0x00                          // CRC placeholder
+  };
+
+  size_t crc_len = sizeof(frame) - 2;
+  uint16_t crc = estia_crc16(frame, crc_len);
+  frame[crc_len]     = (crc >> 8) & 0xFF;
+  frame[crc_len + 1] = crc & 0xFF;
+
+  ESP_LOGD(TAG, "TX: DHW %s (cmd=0x%02X)", on ? "ON" : "OFF", dhw_cmd);
+  log_raw_data("Estia TX", frame, sizeof(frame));
+
+  this->send_estia_tracked_(frame, sizeof(frame), 0x0041);  // ACK: 00:A1:00:41 (shared with power)
+}
+
 void ToshibaAbClimate::send_estia_mode(uint8_t mode_cmd) {
   if (this->read_only_) {
     ESP_LOGW(TAG, "Read-only mode: not sending Estia mode command");
@@ -3841,6 +3887,21 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
 
 void ToshibaAbEstiaZone1Switch::write_state(bool state) {
   this->climate_->send_estia_first_gen_zone1(state);
+}
+
+void ToshibaAbEstiaDhwSwitch::write_state(bool state) {
+  // A0-native command (dtype 00:41, cmd 2C/28) confirmed from a real capture
+  // of the physical wired remote; on true first-generation Estia buses, DHW
+  // on/off is controlled through the existing first-gen helper instead.
+  if (this->climate_->is_estia_first_gen()) {
+    if (state) {
+      this->climate_->send_estia_first_gen_dhw_on();
+    } else {
+      this->climate_->send_estia_first_gen_dhw_off();
+    }
+  } else {
+    this->climate_->send_estia_dhw(state);
+  }
 }
 
 void ToshibaAbEstiaDhwBoostSwitch::write_state(bool state) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -935,6 +935,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
 
   void set_read_only_switch(switch_::Switch *read_only_switch) { read_only_switch_ = read_only_switch; }
   void set_zone1_switch(switch_::Switch *zone1_switch) { zone1_switch_ = zone1_switch; }
+  void set_dhw_switch(switch_::Switch *dhw_switch) { dhw_switch_ = dhw_switch; }
+  void send_estia_dhw(bool on);  // A0-native DHW on/off (dtype 00:41, cmd 2C=on/28=off)
   void set_dhw_boost_switch(switch_::Switch *dhw_boost_switch) { dhw_boost_switch_ = dhw_boost_switch; }
   void set_antibacteria_switch(switch_::Switch *antibacteria_switch) { antibacteria_switch_ = antibacteria_switch; }
 
@@ -1067,6 +1069,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   switch_::Switch *vent_switch_{nullptr};
   switch_::Switch *read_only_switch_{nullptr};
   switch_::Switch *zone1_switch_{nullptr};
+  switch_::Switch *dhw_switch_{nullptr};
   switch_::Switch *dhw_boost_switch_{nullptr};
   switch_::Switch *antibacteria_switch_{nullptr};
   sensor::Sensor *failed_crcs_sensor_{nullptr};
@@ -1267,6 +1270,14 @@ class ToshibaAbVentSwitch : public switch_::Switch, public Component {
 class ToshibaAbEstiaZone1Switch : public switch_::Switch, public Component {
  public:
   ToshibaAbEstiaZone1Switch(ToshibaAbClimate *climate) { climate_ = climate; }
+ protected:
+  void write_state(bool state) override;
+  ToshibaAbClimate *climate_;
+};
+
+class ToshibaAbEstiaDhwSwitch : public switch_::Switch, public Component {
+ public:
+  ToshibaAbEstiaDhwSwitch(ToshibaAbClimate *climate) { climate_ = climate; }
  protected:
   void write_state(bool state) override;
   ToshibaAbClimate *climate_;


### PR DESCRIPTION
## Summary

Adds a new optional `dhw_switch` entity for the A0 (Estia) protocol that lets Home Assistant turn hot-water (DHW) production on/off directly, independent of the main heating/cooling power switch.

- New A0 TX frame in `send_estia_dhw()`: dtype `00:41` (same channel as system power), with dedicated command bytes `0x2C` (on) / `0x28` (off), confirmed by capturing the physical wired remote's own frames.
- State is decoded from bit `0x02` of the status flags byte, present in both the periodic Master Status broadcast (`0x58`) and the immediate State Change broadcast (`0x1C`), and published to the new switch.
- On genuine first-generation Estia buses (no A0 status broadcasts), falls back to the existing first-gen DHW on/off helpers instead of sending an A0 frame the bus doesn't support.
- Respects `read_only: true` (logs a warning, does not transmit).

## Testing

Validated with `esphome config` (schema/codegen validation). I was not able to run a full hardware compile in the environment I used to prepare this change (network restrictions blocked the PlatformIO package registry), but the underlying A0 frame and status-flag decoding have been confirmed against a real Toshiba Estia R32 heat pump.
