### PR TITLE
Mode select

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 import esphome.final_validate as fv
-from esphome.components import climate, uart, binary_sensor, sensor, switch, text_sensor, template
+from esphome.components import climate, uart, binary_sensor, sensor, switch, text_sensor, template, select
 from esphome.const import (
     CONF_ID,
     CONF_NAME,
@@ -30,7 +30,7 @@ from esphome.const import (
 from esphome.core import CORE
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["climate", "binary_sensor", "sensor", "switch", "text_sensor"]
+AUTO_LOAD = ["climate", "binary_sensor", "sensor", "switch", "text_sensor", "select"]
 CODEOWNERS = ["@muxa"]
 
 toshiba_ab_ns = cg.esphome_ns.namespace("toshiba_ab")
@@ -77,6 +77,7 @@ CONF_DEMAND_ENABLED = "demand_enabled"
 CONF_ZONE1_SWITCH = "zone1_switch"
 CONF_DHW_BOOST = "dhw_boost"
 CONF_ANTIBACTERIA = "antibacteria"
+CONF_AUTOMATIK_SELECT = "automatik_select"
 CONF_ZONE1_WATER_TEMPERATURE = "zone1_water_temperature"
 CONF_ZONE1_TARGET_TEMPERATURE = "zone1_target_temperature"
 CONF_DHW_CURRENT_TEMPERATURE = "dhw_current_temperature"
@@ -118,6 +119,9 @@ ToshibaAbEstiaDhwBoostSwitch = toshiba_ab_ns.class_(
 )
 ToshibaAbEstiaAntibacteriaSwitch = toshiba_ab_ns.class_(
     "ToshibaAbEstiaAntibacteriaSwitch", switch.Switch, cg.Component
+)
+ToshibaAbEstiaAutomatikSelect = toshiba_ab_ns.class_(
+    "ToshibaAbEstiaAutomatikSelect", select.Select, cg.Component
 )
 
 ToshibaAbOnDataReceivedTrigger = toshiba_ab_ns.class_(
@@ -258,6 +262,16 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
                     }
                 )
             ),
+            key=CONF_NAME,
+        ),
+        # Automatik/Heizkurve vs. Manuell/Fest, confirmed from a real capture
+        # of the physical remote's own "Automatik" button (dtype 03:C4;
+        # flips bit 0x04 of the status mode byte). A select entity with
+        # options "Automatik"/"Manuell" instead of a plain on/off switch, so
+        # the entity's state text reads the actual mode names. A0-protocol
+        # (Estia) only.
+        cv.Optional(CONF_AUTOMATIK_SELECT): cv.maybe_simple_value(
+            select.select_schema(ToshibaAbEstiaAutomatikSelect),
             key=CONF_NAME,
         ),
         cv.Optional(CONF_ZONE1_WATER_TEMPERATURE): sensor.sensor_schema(
@@ -536,6 +550,11 @@ async def to_code(config):
     if CONF_ANTIBACTERIA in config:
         sw = await switch.new_switch(config[CONF_ANTIBACTERIA], var)
         cg.add(var.set_antibacteria_switch(sw))
+    if CONF_AUTOMATIK_SELECT in config:
+        sel = await select.new_select(
+            config[CONF_AUTOMATIK_SELECT], var, options=["Automatik", "Manuell"]
+        )
+        cg.add(var.set_automatik_select(sel))
 
     if CONF_ON_DATA_RECEIVED in config:
         for on_data_received in config.get(CONF_ON_DATA_RECEIVED, []):

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -2338,6 +2338,15 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
       bool is_cooling = (flags & 0x20) != 0;
       bool is_heating = (flags & 0x40) != 0;
 
+      // Bit 0x04 of the mode byte (raw[10]) is Automatik/Heizkurve mode —
+      // confirmed from a real capture of the physical remote's own
+      // "Automatik" toggle (dtype 03:C4 command, see send_estia_automatik_mode()):
+      // mode went 0x80 -> 0x84 on activation and back to 0x80 on deactivation.
+      if (this->automatik_select_ != nullptr) {
+        bool automatik_on = (estia_mode & 0x04) != 0;
+        this->automatik_select_->publish_state(automatik_on ? "Automatik" : "Manuell");
+      }
+
       ESP_LOGV(TAG, "Status: power=%s flags=0x%02X %s current=%.1f°C setpoint=%.1f°C outdoor=%.1f°C",
                power_on ? "ON" : "OFF", flags,
                is_cooling ? "COOL" : (is_heating ? "HEAT" : "???"),
@@ -2431,10 +2440,15 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
     // Layout same as 0x58: [9]=flags [12]=current [13]=setpoint [14]=outdoor
     if (frame_type == 0x1C && frame_len >= 15 && frame->raw[7] == 0x03 && frame->raw[8] == 0xC6) {
       uint8_t flags = frame->raw[9];
+      uint8_t estia_mode = frame->raw[10];
       bool power_on = (flags & 0x01) != 0;
       bool is_cooling = (flags & 0x20) != 0;
       bool is_heating = (flags & 0x40) != 0;
       float setpoint = frame->raw[13] / 2.0f - 16.0f;
+      if (this->automatik_select_ != nullptr) {
+        bool automatik_on = (estia_mode & 0x04) != 0;
+        this->automatik_select_->publish_state(automatik_on ? "Automatik" : "Manuell");
+      }
 
       climate::ClimateMode new_mode;
       if (!power_on) {
@@ -3456,6 +3470,48 @@ void ToshibaAbClimate::send_estia_mode(uint8_t mode_cmd) {
   this->send_estia_tracked_(frame, sizeof(frame), 0x03C0);  // ACK: 00:A1:03:C0
 }
 
+void ToshibaAbClimate::send_estia_automatik_mode(bool on) {
+  if (this->read_only_) {
+    ESP_LOGW(TAG, "Read-only mode: not sending Estia Automatik mode command");
+    return;
+  }
+
+  uint16_t src = this->estia_source_address_;
+
+  // Captured directly from the physical wired remote's own "Automatik"
+  // toggle (dtype 03:C4):
+  //   TX: 11:0B:00:00:40:08:00:03:C4:01:01:00:00:CRC  -> ACK 00:A1:03:C4,
+  //       status mode byte (raw[10]) goes 0x80 -> 0x84
+  //   TX: 11:0B:00:00:40:08:00:03:C4:01:00:00:00:CRC  -> ACK 00:A1:03:C4,
+  //       status mode byte goes back to 0x80
+  uint8_t value = on ? 0x01 : 0x00;
+
+  // Command frame: A0:00:11:0B:00:SRC_H:SRC_L:08:00:03:C4:01:VALUE:00:00:CRC
+  uint8_t frame[] = {
+    0xA0, 0x00,
+    0x11,
+    0x0B,
+    0x00,
+    (uint8_t)(src >> 8), (uint8_t)(src & 0xFF),
+    0x08, 0x00,
+    0x03, 0xC4,
+    0x01,   // marker, constant in both captured frames
+    value,  // 0x01 = Automatik on, 0x00 = Automatik off
+    0x00, 0x00,
+    0x00, 0x00  // CRC placeholder
+  };
+
+  size_t crc_len = sizeof(frame) - 2;
+  uint16_t crc = estia_crc16(frame, crc_len);
+  frame[crc_len]     = (crc >> 8) & 0xFF;
+  frame[crc_len + 1] = crc & 0xFF;
+
+  ESP_LOGD(TAG, "TX: Automatik mode=%s", on ? "ON" : "OFF");
+  log_raw_data("Estia TX", frame, sizeof(frame));
+
+  this->send_estia_tracked_(frame, sizeof(frame), 0x03C4);  // ACK: 00:A1:03:C4
+}
+
 void ToshibaAbClimate::estia_mode_retry_timeout_() {
   if (!this->estia_power_on_pending_) return;
 
@@ -3849,6 +3905,23 @@ void ToshibaAbEstiaDhwBoostSwitch::write_state(bool state) {
 
 void ToshibaAbEstiaAntibacteriaSwitch::write_state(bool state) {
   this->climate_->send_estia_first_gen_antibacteria(state);
+}
+
+void ToshibaAbEstiaAutomatikSelect::control(const std::string &value) {
+  // Automatik/Manuell toggle (dtype 03:C4) is an A0-only frame; there's no
+  // known first-generation equivalent, so refuse rather than sending an A0
+  // frame that a first-gen bus wouldn't understand.
+  if (this->climate_->is_estia_first_gen()) {
+    ESP_LOGW(TAG, "automatik_select is only supported on A0-protocol (Estia) systems");
+    return;
+  }
+  if (value == "Automatik") {
+    this->climate_->send_estia_automatik_mode(true);
+  } else if (value == "Manuell") {
+    this->climate_->send_estia_automatik_mode(false);
+  } else {
+    ESP_LOGW(TAG, "automatik_select: unknown option '%s'", value.c_str());
+  }
 }
 
 void ToshibaAbVentSwitch::write_state(bool state) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -2,6 +2,7 @@
 
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/climate/climate.h"
+#include "esphome/components/select/select.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
@@ -937,6 +938,12 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_zone1_switch(switch_::Switch *zone1_switch) { zone1_switch_ = zone1_switch; }
   void set_dhw_boost_switch(switch_::Switch *dhw_boost_switch) { dhw_boost_switch_ = dhw_boost_switch; }
   void set_antibacteria_switch(switch_::Switch *antibacteria_switch) { antibacteria_switch_ = antibacteria_switch; }
+  void set_automatik_select(select::Select *automatik_select) { automatik_select_ = automatik_select; }
+  // Toggles Automatik/Heizkurve (on) vs. Manuell/Fest (off) mode, dtype 03:C4.
+  // Confirmed from a real capture of the physical remote's own "Automatik"
+  // toggle: payload 01:01:00:00 (on) / 01:00:00:00 (off), which flips bit
+  // 0x04 of the status-broadcast mode byte (raw[10]) between 0x84 and 0x80.
+  void send_estia_automatik_mode(bool on);
 
   void set_failed_crcs_sensor(sensor::Sensor *failed_crcs_sensor) { this->failed_crcs_sensor_ = failed_crcs_sensor; }
   void set_noise_rate_sensor(sensor::Sensor *sensor) { this->noise_rate_sensor_ = sensor; }
@@ -1069,6 +1076,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   switch_::Switch *zone1_switch_{nullptr};
   switch_::Switch *dhw_boost_switch_{nullptr};
   switch_::Switch *antibacteria_switch_{nullptr};
+  select::Select *automatik_select_{nullptr};
   sensor::Sensor *failed_crcs_sensor_{nullptr};
   sensor::Sensor *noise_rate_sensor_{nullptr};
   sensor::Sensor *crc_failures_5min_sensor_{nullptr};
@@ -1285,6 +1293,17 @@ class ToshibaAbEstiaAntibacteriaSwitch : public switch_::Switch, public Componen
   ToshibaAbEstiaAntibacteriaSwitch(ToshibaAbClimate *climate) { climate_ = climate; }
  protected:
   void write_state(bool state) override;
+  ToshibaAbClimate *climate_;
+};
+
+// Automatik/Heizkurve vs. Manuell/Fest as a select entity (options
+// "Automatik"/"Manuell") instead of a plain on/off switch, so the entity's
+// own state text reads the actual mode names rather than generic "An"/"Aus".
+class ToshibaAbEstiaAutomatikSelect : public select::Select, public Component {
+ public:
+  ToshibaAbEstiaAutomatikSelect(ToshibaAbClimate *climate) { climate_ = climate; }
+ protected:
+  void control(const std::string &value) override;
   ToshibaAbClimate *climate_;
 };
 


### PR DESCRIPTION
## Summary

Adds a new optional `automatik_select` entity for the A0 (Estia) protocol mirroring the physical wired remote's own "Automatik" button, so Home Assistant can read and toggle Heizkurve-based (Automatik) vs. fixed (Manuell/Fest) heating curve mode.

- Modeled as a select entity with options "Automatik"/"Manuell" rather than a plain switch, so the entity's own state text reads the actual mode names instead of generic on/off.
- New A0 TX frame in `send_estia_automatik_mode()`: dtype `03:C4`, captured directly from the physical remote's own Automatik toggle (payload `01:01:00:00` on / `01:00:00:00` off).
- State is decoded from bit `0x04` of the status mode byte (`raw[10]`), present in both the periodic Master Status broadcast (`0x58`) and the immediate State Change broadcast (`0x1C`), and published to the new select entity.
- A0-protocol (Estia) only; refuses with a warning on first-generation Estia buses, since there's no known equivalent command there.
- Respects `read_only: true` (logs a warning, does not transmit).

## Testing

Validated with `esphome config` (schema/codegen validation). I was not able to run a full hardware compile in the environment I used to prepare this change (network restrictions blocked the PlatformIO package registry), but the frame and status-byte decoding have been confirmed against a real Toshiba Estia R32 heat pump.
