### PR TITLE
Restore visible ESPHome flashing and AC wiring instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,63 @@ protocols within related product ranges. Confirm that your unit has an AB port,
 then use the selection tables below and the
 [protocol/frame-format reference](docs/frame_formats.md).
 
+## Start here: flash and connect the board
+
+These essential installation steps are deliberately kept visible rather than
+inside a collapsible section. Read the complete [hardware guide](docs/hardware.md)
+before building a board or substituting components.
+
+### 1. Flash ESPHome over USB
+
+1. Start with [`example.yaml`](example.yaml), or copy the minimal configuration
+   from the air-to-air/ESTIA section below. Add your normal ESPHome Wi-Fi, API,
+   OTA and secrets settings.
+2. Select the UART pins for your board: v3.2 uses TX `GPIO12` and RX `GPIO13`;
+   v3 uses TX `GPIO10` and RX `GPIO13`; v1 uses TX `GPIO15` and RX `GPIO13`;
+   D1 mini uses TX `D8` and RX `D7`. Also select the parity and `frame_format`
+   required by your AC system in the tables below.
+3. **Leave the AC's A/B wires disconnected.** With all power removed, put the
+   board's power-selection jumper/switch (if fitted) in the **USB** position,
+   then attach it to the computer with a data-capable USB cable.
+4. In the ESPHome dashboard, open the device and choose **Install → Plug into
+   this computer**, or run `esphome run your-device.yaml` from the ESPHome CLI
+   and select the USB serial port. Follow ESPHome's
+   [first-device connection guide](https://esphome.io/guides/physical_device_connection/)
+   if the serial device is not detected.
+5. For v3.2, if flashing does not start, disconnect USB, hold **BOOT**, reconnect
+   USB while continuing to hold **BOOT**, and retry the installation. When the
+   upload finishes, confirm that the device boots, joins Wi-Fi and appears in
+   ESPHome/Home Assistant. Later firmware updates can be installed over Wi-Fi.
+
+### 2. Connect the board to the AC system
+
+> **Electrical safety:** completely isolate the HVAC system at the distribution
+> board before opening the wired controller or indoor unit. Hazardous voltages
+> may be present nearby. Never connect the A/B bus directly to ESP UART pins.
+
+1. Disconnect USB and switch off/isolate the complete HVAC system.
+2. Remove the wired controller cover and locate its two **A/B remote-bus**
+   terminals (or use the indoor unit's documented A/B controller terminals).
+   Loosen the terminal screws without removing the existing controller wires.
+3. Run a two-core cable from those A and B terminals to the board's A and B
+   screw terminals. The v1 board is polarity-sensitive, so match A to A and B
+   to B; v3 and v3.2 accept either polarity.
+4. With both USB and the AC still disconnected, move the board's power selector
+   (if fitted) to **AB**. Never move the selector while either power source is
+   connected.
+5. Check the wiring, refit the controller cover, restore HVAC power, and inspect
+   the ESPHome logs for valid frames and a connected state before sending any
+   commands.
+
+The board is connected **in parallel** with the wired controller; it does not
+replace or interrupt the existing A/B pair. Autonomous operation without a wall
+controller is an advanced option documented in
+[`complete_example.yaml`](complete_example.yaml).
+
+The A/B screws on a typical wired-controller PCB look like this:
+
+![A/B terminals on the back of a Toshiba wired controller](https://github.com/issalig/toshiba_air_cond/blob/master/pcb/remote_back_pcb.jpg?raw=true)
+
 <details>
 <summary><strong>Hardware design, construction, installation and case</strong></summary>
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -42,7 +42,12 @@ sensor, or another ESPHome-compatible I²C device.
 3. Fit any through-hole capacitors or modules omitted by the assembly service.
 4. For the first ESPHome flash, select **USB** power and connect USB. On v3.2,
    hold **BOOT** while applying USB power to enter flashing mode if necessary.
-5. After the initial flash, normal updates can be installed over the air.
+5. In the ESPHome dashboard choose **Install → Plug into this computer**, or run
+   `esphome run your-device.yaml` and select the USB serial port. See ESPHome's
+   [first-device connection guide](https://esphome.io/guides/physical_device_connection/)
+   for USB driver and browser-installation details.
+6. Confirm that the board boots and joins Wi-Fi. After the initial flash, normal
+   updates can be installed over the air.
 
 Never change the power selector while the board is powered. Disconnect both USB
 and the AB line before moving the jumper or switch.
@@ -55,9 +60,10 @@ and the AB line before moving the jumper or switch.
 1. Flash and validate the ESPHome board before connecting the AB line.
 2. Completely isolate power to the HVAC system.
 3. Remove the wired controller cover and loosen its A/B terminal screws, or use
-   the unit's documented AB connection point.
-4. Wire A and B to the PCB. v1 is polarity-sensitive; v3 and v3.2 can be connected
-   either way.
+   the unit's documented AB connection point. Leave the controller's existing
+   wires in place: the interface board connects in parallel.
+4. Wire A and B to the PCB. v1 is polarity-sensitive (A to A and B to B); v3 and
+   v3.2 can be connected either way.
 5. With USB disconnected, select **AB** power on boards that have a selector.
 6. Reassemble the controller, restore HVAC power and inspect ESPHome logs for
    valid frames before sending commands.


### PR DESCRIPTION
### Motivation

- Reintroduce the essential USB flashing and A/B wiring guidance that was previously hidden inside collapsible sections so users can find quick-start instructions immediately.  
- Provide clear, board-specific flashing and UART pin/parity guidance for all supported hardware revisions to reduce user errors during first flash.  
- Emphasise electrical safety and correct A/B wiring (parallel connection and polarity differences) so installations are done safely and reliably.

### Description

- Add a prominent "Start here: flash and connect the board" section to `README.md` with step-by-step USB flashing instructions, board-specific UART pin recommendations, parity/frame_format notes, and v3.2 BOOT-button instructions.  
- Add a clear, step-by-step AC-connection procedure in `README.md` that covers isolating power, locating A/B terminals, wiring the interface in parallel, power-selector guidance, and validation of frames in ESPHome logs, plus an inline reference image of the controller A/B terminals.  
- Expand `docs/hardware.md` to include explicit ESPHome dashboard/CLI flashing steps and clarify that the interface connects in parallel without removing the controller's existing wiring, and refine polarity and selector wording for v1/v3/v3.2 boards.  

### Testing

- Ran `git diff --check` and found no style errors.  
- Executed a local Markdown link validation script that verified referenced local files (for example `example.yaml`, `complete_example.yaml`, and `docs/hardware.md`) exist and resolve.  
- Confirmed repository status shows no outstanding uncommitted changes after applying the documentation updates, and attempted an external ESPHome link check failed due to an outbound/network proxy 403 from the environment but does not affect the repository changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9cae6fc404832f9f66e7caf65519c5)