### PR TITLE
Add water-system thermostats (DHW/Zone1/Zone2) and configuration for Toshiba AB component

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -20,17 +20,22 @@ toshiba_ab_ns = cg.esphome_ns.namespace("toshiba_ab")
 ToshibaAbClimate = toshiba_ab_ns.class_(
     "ToshibaAbClimate", climate.Climate, uart.UARTDevice, cg.Component
 )
+ToshibaAbThermostat = toshiba_ab_ns.class_("ToshibaAbThermostat", climate.Climate)
 ResetButton = toshiba_ab_ns.class_("ResetButton", button.Button)
 DiagnosticTextSensor = toshiba_ab_ns.class_(
     "DiagnosticTextSensor", text_sensor.TextSensor
 )
 Protocol = toshiba_ab_ns.enum("Protocol", is_class=True)
 SystemType = toshiba_ab_ns.enum("SystemType", is_class=True)
+WaterCircuit = toshiba_ab_ns.enum("WaterCircuit", is_class=True)
 
 CONF_MASTER_ADDRESS = "master_address"
 CONF_ESP_ADDRESS = "esp_address"
 CONF_FORMAT = "format"
 CONF_SYSTEM_TYPE = "system_type"
+CONF_DHW = "dhw"
+CONF_ZONE_1 = "zone_1"
+CONF_ZONE_2 = "zone_2"
 CONF_DIAGNOSTIC = "diagnostic"
 CONF_HARDWARE_UART_RX_PIN = "hardware_uart_rx_pin"
 CONF_RESET_BUTTON = "reset_button"
@@ -50,6 +55,24 @@ FORMATS = {
     "a0": Protocol.A0,
 }
 SYSTEM_TYPES = {"air": SystemType.AIR, "water": SystemType.WATER}
+WATER_CIRCUITS = {
+    CONF_DHW: WaterCircuit.DHW,
+    CONF_ZONE_1: WaterCircuit.ZONE_1,
+    CONF_ZONE_2: WaterCircuit.ZONE_2,
+}
+
+
+def _water_thermostat(default_name):
+    schema = climate.climate_schema(ToshibaAbThermostat)
+
+    def validate(value):
+        if value is False:
+            return False
+        if value is True:
+            value = {CONF_NAME: default_name}
+        return schema(value)
+
+    return validate
 
 CONFIG_SCHEMA = (
     climate._CLIMATE_SCHEMA.extend(
@@ -68,9 +91,12 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_MASTER_ADDRESS, default="auto"): _address,
             cv.Optional(CONF_ESP_ADDRESS, default="auto"): _address,
             cv.Optional(CONF_FORMAT, default="auto"): cv.enum(FORMATS, lower=True),
-            cv.Optional(CONF_SYSTEM_TYPE, default="Air"): cv.enum(
-                SYSTEM_TYPES, lower=True
+            cv.Optional(CONF_SYSTEM_TYPE, default="air"): cv.one_of(
+                *SYSTEM_TYPES, lower=True
             ),
+            cv.Optional(CONF_DHW, default=True): _water_thermostat("DHW"),
+            cv.Optional(CONF_ZONE_1, default=True): _water_thermostat("Zone 1"),
+            cv.Optional(CONF_ZONE_2, default=False): _water_thermostat("Zone 2"),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -114,12 +140,23 @@ FINAL_VALIDATE_SCHEMA = _validate_uart
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await climate.register_climate(var, config)
+    if config[CONF_SYSTEM_TYPE] == "air":
+        await climate.register_climate(var, config)
     await uart.register_uart_device(var, config)
     cg.add(var.set_master_address(config[CONF_MASTER_ADDRESS]))
     cg.add(var.set_esp_address(config[CONF_ESP_ADDRESS]))
     cg.add(var.set_protocol(config[CONF_FORMAT]))
-    cg.add(var.set_system_type(config[CONF_SYSTEM_TYPE]))
+    cg.add(var.set_system_type(SYSTEM_TYPES[config[CONF_SYSTEM_TYPE]]))
+
+    if config[CONF_SYSTEM_TYPE] == "water":
+        for key, circuit in WATER_CIRCUITS.items():
+            thermostat_config = config[key]
+            if thermostat_config is False:
+                continue
+            thermostat = cg.new_Pvariable(
+                thermostat_config[CONF_ID], var, circuit
+            )
+            await climate.register_climate(thermostat, thermostat_config)
     if CONF_HARDWARE_UART_RX_PIN in config:
         cg.add(var.set_hardware_uart_rx_pin(config[CONF_HARDWARE_UART_RX_PIN]))
 

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -14,6 +14,35 @@ constexpr ProtocolValue ToshibaAbClimate::MASTER_KEEPALIVE_OPCODE;
 constexpr ProtocolValue ToshibaAbClimate::MASTER_KEEPALIVE_LENGTH;
 constexpr ProtocolValue ToshibaAbClimate::MASTER_KEEPALIVE_DATA_TYPE;
 
+ToshibaAbThermostat::ToshibaAbThermostat(ToshibaAbClimate *parent, WaterCircuit circuit)
+    : parent_(parent), circuit_(circuit) {
+  this->mode = climate::CLIMATE_MODE_OFF;
+  this->target_temperature = circuit == WaterCircuit::DHW ? 50.0f : 22.0f;
+}
+
+climate::ClimateTraits ToshibaAbThermostat::traits() {
+  auto traits = climate::ClimateTraits();
+  traits.set_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
+  // Hydronic controllers expose these operating presets independently of the
+  // circuit's heat/cool mode. Keep them on DHW and both zones so each entity
+  // can eventually report and control the corresponding water-system state.
+  traits.set_supported_presets(
+      {climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_ECO});
+  if (circuit_ == WaterCircuit::DHW) {
+    traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT});
+    traits.set_visual_min_temperature(45);
+    traits.set_visual_max_temperature(60);
+  } else {
+    traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_COOL});
+    traits.set_visual_min_temperature(20);
+    traits.set_visual_max_temperature(65);
+  }
+  traits.set_visual_temperature_step(0.5);
+  return traits;
+}
+
+void ToshibaAbThermostat::control(const climate::ClimateCall &call) { parent_->control_water(circuit_, call); }
+
 void ResetButton::press_action() {
   if (parent_ != nullptr)
     parent_->reset();
@@ -449,10 +478,12 @@ climate::ClimateTraits ToshibaAbClimate::traits() {
     traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL,
                                 climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_FAN_ONLY, climate::CLIMATE_MODE_DRY,
                                 climate::CLIMATE_MODE_AUTO});
-    traits.set_supported_fan_modes({climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH});
+    traits.set_supported_fan_modes(
+        {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH});
     traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH,
                                       climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL});
-    traits.set_supported_presets({climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_ECO, climate::CLIMATE_PRESET_SLEEP});
+    traits.set_supported_presets({climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_BOOST,
+                                  climate::CLIMATE_PRESET_ECO, climate::CLIMATE_PRESET_SLEEP});
   } else {
     traits.set_supported_modes({climate::CLIMATE_MODE_OFF});
   }
@@ -464,6 +495,11 @@ climate::ClimateTraits ToshibaAbClimate::traits() {
 
 void ToshibaAbClimate::control(const climate::ClimateCall &call) {
   ESP_LOGV(TAG, "Climate control ignored while the component is identification-only");
+}
+
+void ToshibaAbClimate::control_water(WaterCircuit circuit, const climate::ClimateCall &call) {
+  const char *name = circuit == WaterCircuit::DHW ? "DHW" : (circuit == WaterCircuit::ZONE_1 ? "Zone 1" : "Zone 2");
+  ESP_LOGV(TAG, "%s climate control ignored while the component is identification-only", name);
 }
 
 void ToshibaAbClimate::dump_config() {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -13,8 +13,20 @@ namespace toshiba_ab {
 
 enum class Protocol : uint8_t { AUTO, TCC, TU2C, A0 };
 enum class SystemType : uint8_t { AIR, WATER };
+enum class WaterCircuit : uint8_t { DHW, ZONE_1, ZONE_2 };
 
 class ToshibaAbClimate;
+
+class ToshibaAbThermostat : public climate::Climate {
+ public:
+  ToshibaAbThermostat(ToshibaAbClimate *parent, WaterCircuit circuit);
+  climate::ClimateTraits traits() override;
+  void control(const climate::ClimateCall &call) override;
+
+ protected:
+  ToshibaAbClimate *parent_;
+  WaterCircuit circuit_;
+};
 
 class ResetButton : public button::Button {
  public:
@@ -49,6 +61,7 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   climate::ClimateTraits traits() override;
   void control(const climate::ClimateCall &call) override;
   void reset();
+  void control_water(WaterCircuit circuit, const climate::ClimateCall &call);
 
   void set_master_address(uint8_t address) { master_setting_ = address; }
   void set_esp_address(uint8_t address) { esp_address_ = address; }

--- a/docs/new_code_progress.md
+++ b/docs/new_code_progress.md
@@ -160,9 +160,11 @@ behavior and should be revisited if address mismatch recovery is desired.
 ### 6. Climate behavior during this phase
 
 For an air system, the entity advertises the intended modes and controls so API
-clients can retain the eventual entity schema while development continues. For
-a water system, only off mode is currently advertised. The visual temperature
-range is 16–32 °C in 0.5 °C increments for both.
+clients can retain the eventual entity schema while development continues. A
+water system creates separate `DHW` and `Zone 1` thermostats by default, with an
+optional `Zone 2` thermostat. DHW advertises off/heat and a 45–60 °C range;
+both zones advertise off/heat/cool and a 20–65 °C range. All three water
+thermostats offer normal, boost, and eco presets and use 0.5 °C steps.
 
 These capabilities must not be interpreted as functional support yet:
 
@@ -176,6 +178,9 @@ These capabilities must not be interpreted as functional support yet:
 | --- | --- | --- |
 | `format` | `auto` | Select `auto`, `tcc`, `a0`, or `tu2c`. |
 | `system_type` | `air` | Select the currently advertised air or water climate traits. |
+| `dhw` | `true` | Create the water system's domestic-hot-water thermostat; set to `false` to omit it. |
+| `zone_1` | `true` | Create the water system's first heating/cooling thermostat; set to `false` to omit it. |
+| `zone_2` | `false` | Create a second heating/cooling thermostat when enabled. |
 | `master_address` | `auto` (`0xAA` internally) | Learn the master or require an explicit 8-bit address. |
 | `esp_address` | `auto` (`0xAA` internally) | Stores the future local address; it is not yet used to transmit. |
 | `diagnostic` | `Toshiba AB Diagnostic` | Text sensor containing recent discovery events. |

--- a/example.yaml
+++ b/example.yaml
@@ -38,3 +38,9 @@ climate:
     esp_address: auto
     format: auto
     system_type: Air
+
+    # Water systems expose DHW and Zone 1 by default. Set either to false to
+    # hide it, or enable the optional second heating/cooling circuit:
+    # dhw: true
+    # zone_1: true
+    # zone_2: false


### PR DESCRIPTION
### Motivation
- Extend the identification-only Toshiba AB component to advertise water-system thermostats (DHW and heating/cooling zones) in addition to the existing air-system behavior.
- Provide explicit YAML options to enable or disable each water circuit so users can expose only the thermostats they need.

### Description
- Add a `WaterCircuit` enum and a new `ToshibaAbThermostat` class that implements `climate::Climate` for per-circuit water thermostats and delegates control calls to `ToshibaAbClimate::control_water`.
- Extend the YAML schema with boolean options `dhw`, `zone_1`, and `zone_2` that default to `true`, `true`, and `false` respectively, and add a `_water_thermostat` helper to accept `true`/`false` or a nested `climate` config.
- When `system_type` is `water`, create per-circuit climate entities for enabled circuits instead of registering the single air climate entity, and map `system_type` to the internal `SystemType` enum.
- Implement thermostat traits and a stub `control_water` that logs control attempts; update documentation and `example.yaml` to document the new options and default behaviors.

### Testing
- Validated the configuration schema with `esphome config` against the updated `example.yaml`, which succeeded.
- Built the component sources to ensure the added C++ classes compile with the project build (local `platformio` build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9d32da0e68832f8b42520400f83a62)