### PR TITLE
Detect and log remote ping frames; add protocol constants and docs update

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -13,6 +13,9 @@ static const char *const TAG = "toshiba_ab";
 constexpr ProtocolValue ToshibaAbClimate::MASTER_KEEPALIVE_OPCODE;
 constexpr ProtocolValue ToshibaAbClimate::MASTER_KEEPALIVE_LENGTH;
 constexpr ProtocolValue ToshibaAbClimate::MASTER_KEEPALIVE_DATA_TYPE;
+constexpr ProtocolValue ToshibaAbClimate::REMOTE_PING_OPCODE;
+constexpr ProtocolValue ToshibaAbClimate::REMOTE_PING_LENGTH;
+constexpr ProtocolValue ToshibaAbClimate::REMOTE_PING_DATA_TYPE;
 
 ToshibaAbThermostat::ToshibaAbThermostat(ToshibaAbClimate *parent, WaterCircuit circuit)
     : parent_(parent), circuit_(circuit) {
@@ -265,9 +268,17 @@ void ToshibaAbClimate::check_reader_timeout_(uint32_t now) {
 void ToshibaAbClimate::process_frame_(Protocol protocol, const uint8_t *data, size_t size, bool crc_ok) {
   uint8_t source = 0;
   const bool master_keepalive = crc_ok && is_master_keepalive_(protocol, data, size, source);
-  const char *description = master_keepalive ? "master keepalive" : (crc_ok ? "" : "CRC failed");
+  const bool remote_ping = crc_ok && !master_keepalive && is_remote_ping_(protocol, data, size, source);
+  std::string description;
+  if (!crc_ok) {
+    description = "CRC failed";
+  } else if (master_keepalive) {
+    description = "master keepalive " + hex_(&source, 1);
+  } else if (remote_ping) {
+    description = "remote ping " + hex_(&source, 1);
+  }
   ESP_LOGD(TAG, "RX %s: %s [%s%s%s]", protocol_name_(protocol), colored_hex_(protocol, data, size, crc_ok).c_str(),
-           ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_GREEN), description, ESPHOME_LOG_RESET_COLOR);
+           ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_GREEN), description.c_str(), ESPHOME_LOG_RESET_COLOR);
   if (!crc_ok)
     return;
   if (master_keepalive)
@@ -305,8 +316,42 @@ bool ToshibaAbClimate::is_master_keepalive_(Protocol protocol, const uint8_t *da
 
   // The first master keepalive establishes the source address. Once discovery
   // has completed, do not treat traffic from another participant as a master
-  // keepalive; remote keepalives will be handled separately.
+  // keepalive. Remote pings have separate opcodes and signatures.
   return signature_matches && (!protocol_confirmed_ || source == master_address_);
+}
+
+bool ToshibaAbClimate::is_remote_ping_(Protocol protocol, const uint8_t *data, size_t size, uint8_t &source) const {
+  if (!protocol_confirmed_ || !master_address_confirmed_)
+    return false;
+
+  uint8_t destination = 0;
+  switch (protocol) {
+    case Protocol::TCC:
+      source = size > 0 ? data[0] : 0;
+      destination = size > 1 ? data[1] : 0;
+      break;
+    case Protocol::TU2C:
+      source = size > 3 ? data[3] : 0;
+      destination = size > 4 ? data[4] : 0;
+      break;
+    case Protocol::A0:
+      source = size > 6 ? data[6] : 0;
+      destination = size > 8 ? data[8] : 0;
+      break;
+    default:
+      return false;
+  }
+
+  // Remote pings are requests sent to the master. Do not identify traffic for
+  // another indoor unit as a remote attached to this one.
+  if (destination != master_address_ || source == master_address_)
+    return false;
+
+  const uint16_t data_type = data_type_(protocol, data, size);
+  const bool data_type_matches = data_type == REMOTE_PING_DATA_TYPE.for_protocol(protocol) ||
+                                 (protocol == Protocol::TU2C && data_type == TU2C_FIRST_GEN_REMOTE_PING_DATA_TYPE);
+  return frame_length_(protocol, data, size) == REMOTE_PING_LENGTH.for_protocol(protocol) &&
+         opcode_(protocol, data, size) == REMOTE_PING_OPCODE.for_protocol(protocol) && data_type_matches;
 }
 
 void ToshibaAbClimate::consider_keepalive_(Protocol protocol, uint8_t source) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -84,6 +84,12 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   // and 0x3A is the data type. A0 master heartbeats carry the two-byte data
   // type 00:8A in the corresponding field.
   static constexpr ProtocolValue MASTER_KEEPALIVE_DATA_TYPE{0x8A, 0x3A, 0x008A};
+  static constexpr ProtocolValue REMOTE_PING_OPCODE{0x15, 0x41, 0x55};
+  static constexpr ProtocolValue REMOTE_PING_LENGTH{0x07, 0x0C, 0x0C};
+  static constexpr ProtocolValue REMOTE_PING_DATA_TYPE{0x0C, 0x5C, 0x009F};
+  // First-generation Estia shares the TU2C wire format but uses data type
+  // 0x0C for its remote ping instead of the air protocol's 0x5C.
+  static constexpr uint16_t TU2C_FIRST_GEN_REMOTE_PING_DATA_TYPE = 0x0C;
 
   void read_byte_(uint8_t byte);
   void read_even_byte_(uint8_t byte);
@@ -94,6 +100,7 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   void check_reader_timeout_(uint32_t now);
   void process_frame_(Protocol protocol, const uint8_t *data, size_t size, bool crc_ok);
   bool is_master_keepalive_(Protocol protocol, const uint8_t *data, size_t size, uint8_t &source) const;
+  bool is_remote_ping_(Protocol protocol, const uint8_t *data, size_t size, uint8_t &source) const;
   void consider_keepalive_(Protocol protocol, uint8_t source);
   void set_runtime_parity_(uart::UARTParityOptions parity);
   void diagnostic_(const std::string &message);

--- a/docs/new_code_progress.md
+++ b/docs/new_code_progress.md
@@ -42,6 +42,7 @@ Status meanings:
 | Automatic protocol discovery | Done | Scans TCC, A0, and TU2C for 20 seconds each and confirms a protocol only from a checksum-valid master keepalive. |
 | Runtime UART parity selection | Partial | Selects even parity for TCC/A0 and no parity for TU2C. Includes the existing ESP8266 UART0 GPIO13 swap path; broader hardware validation is still required. |
 | Master-address discovery and validation | Done | Learns the source from the first valid master keepalive or checks it against an explicitly configured address. |
+| Existing remote discovery | Partial | After protocol and master confirmation, labels known checksum-valid remote ping signatures in the normal frame log. Address assignment and a persistent inventory are not implemented yet. |
 | Frame logging | Done | Logs every complete candidate, highlights addresses and command/type fields, and marks checksum failures. |
 | Diagnostic history | Done | Publishes a newline-separated, de-duplicated event history capped at 255 characters. |
 | Manual rediscovery | Done | The diagnostic reset button clears discovery state, reader state, counters, and history, then restarts scanning. |
@@ -137,9 +138,25 @@ wire offsets and magic values throughout discovery. The exact signature also
 prevents an arbitrary TCC frame with opcode `0x10` from being mistaken for the
 master keepalive.
 
-After confirmation, a matching signature from a different source is not
-treated as the master keepalive. This preserves the confirmed master identity
-and leaves room for separate remote-controller keepalive handling later.
+Master keepalives and remote pings remain separate frame types: they use
+different opcodes and signatures within each protocol and are recognized by
+separate predicates. Once both protocol and master are confirmed, the same
+logging pipeline identifies these existing remote-controller pings:
+
+| Protocol / system | Remote ping signature | Log description |
+| --- | --- | --- |
+| TCC | Length `0x07`, opcode `0x15`, payload prefix `08:0C:81` | `remote ping 0xNN` |
+| TU2C air | Length `0x0C`, payload prefix `41:5C` | `remote ping 0xNN` |
+| TU2C first-generation Estia | Length `0x0C`, payload prefix `E0:41:0C` | `remote ping 0xNN` |
+| A0 demand interface | Length `0x0C`, opcode `0x55`, data type `00:9F` | `remote ping 0xNN` |
+
+All of these frames are addressed to the master. Classification therefore
+requires that the frame destination equal the confirmed master address. At
+this stage presence is deliberately observable only through
+the existing debug frame log; addresses are not stored and do not yet influence
+the configured ESP address. As with master keepalive identification, encoded
+lengths, opcodes, and data types are held in protocol-value constants and
+compared through the common semantic field helpers rather than at raw offsets.
 
 ### 5. Confirming protocol and master
 


### PR DESCRIPTION
### Motivation

- Improve frame classification by distinguishing remote-controller "ping" frames from master keepalives so remote presence can be observed in logs after discovery completes.

### Description

- Add `REMOTE_PING_OPCODE`, `REMOTE_PING_LENGTH`, `REMOTE_PING_DATA_TYPE`, and `TU2C_FIRST_GEN_REMOTE_PING_DATA_TYPE` protocol constants and expose `is_remote_ping_` in `toshiba_ab.h`.
- Implement `is_remote_ping_` in `toshiba_ab.cpp` to validate destination/master addressing, protocol-specific offsets, and alternate TU2C first-generation data-type handling.
- Extend `process_frame_` to detect remote pings, build a descriptive log string for master keepalives and remote pings, and log the source address in the existing colored hex frame log.
- Update documentation in `docs/new_code_progress.md` to describe recognized remote-ping signatures and clarify that remote detection is currently observational only.

### Testing

- Performed a local project build via `esphome compile`/`pio run`, and the build completed successfully with no compile errors.
- No new automated parser tests were added in this change; existing CI/unit tests (if present) were exercised by the build and reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9d39ea2e74832f8ec237146ae91fa7)