### PR TITLE
Track active remote addresses with 5‑minute expiry and diagnostic snapshot

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1,5 +1,6 @@
 #include "toshiba_ab.h"
 #include "esphome/core/log.h"
+#include <algorithm>
 #include <cstdio>
 
 #ifdef USE_ESP8266
@@ -79,6 +80,7 @@ void ToshibaAbClimate::reset() {
   protocol_confirmed_ = false;
   discovery_finished_ = false;
   reader_reset_count_ = 0;
+  remotes_.clear();
   diagnostic_history_.clear();
   select_scan_protocol_(protocol_setting_ == Protocol::AUTO ? Protocol::TCC : protocol_setting_);
   diagnostic_(protocol_setting_ == Protocol::AUTO
@@ -90,6 +92,7 @@ void ToshibaAbClimate::loop() {
   const uint32_t now = millis();
   update_discovery_(now);
   check_reader_timeout_(now);
+  expire_remotes_(now);
 
   uint8_t byte;
 #ifdef USE_ESP8266
@@ -283,6 +286,8 @@ void ToshibaAbClimate::process_frame_(Protocol protocol, const uint8_t *data, si
     return;
   if (master_keepalive)
     consider_keepalive_(protocol, source);
+  else if (remote_ping)
+    observe_remote_(source, millis());
 }
 
 bool ToshibaAbClimate::is_master_keepalive_(Protocol protocol, const uint8_t *data, size_t size,
@@ -376,6 +381,32 @@ void ToshibaAbClimate::consider_keepalive_(Protocol protocol, uint8_t source) {
   diagnostic_(std::string("Confirmed ") + protocol_name_(protocol) + " master " + hex_(&source, 1));
 }
 
+void ToshibaAbClimate::observe_remote_(uint8_t address, uint32_t now) {
+  for (auto &remote : remotes_) {
+    if (remote.address == address) {
+      remote.last_seen = now;
+      return;
+    }
+  }
+
+  remotes_.push_back({address, now});
+  std::sort(remotes_.begin(), remotes_.end(),
+            [](const RemotePresence &left, const RemotePresence &right) { return left.address < right.address; });
+  publish_diagnostic_();
+}
+
+void ToshibaAbClimate::expire_remotes_(uint32_t now) {
+  const size_t previous_size = remotes_.size();
+  remotes_.erase(std::remove_if(remotes_.begin(), remotes_.end(),
+                                [now](const RemotePresence &remote) {
+                                  // Unsigned subtraction keeps this correct when millis() wraps.
+                                  return now - remote.last_seen >= REMOTE_EXPIRY_MS;
+                                }),
+                 remotes_.end());
+  if (remotes_.size() != previous_size)
+    publish_diagnostic_();
+}
+
 void ToshibaAbClimate::set_runtime_parity_(uart::UARTParityOptions parity) {
 #ifdef USE_ESP8266
   if (hardware_uart_rx_pin_ == 13 && boot_ms_ != 0) {
@@ -412,8 +443,30 @@ void ToshibaAbClimate::diagnostic_(const std::string &message) {
     }
     diagnostic_history_.erase(0, newline + 1);
   }
-  if (diagnostic_sensor_ != nullptr)
-    diagnostic_sensor_->publish_state(diagnostic_history_);
+  publish_diagnostic_();
+}
+
+std::string ToshibaAbClimate::remote_list_() const {
+  std::string list = "Current remotes:";
+  if (remotes_.empty())
+    return list + " none";
+  for (const auto &remote : remotes_)
+    list += " " + hex_(&remote.address, 1);
+  return list;
+}
+
+void ToshibaAbClimate::publish_diagnostic_() {
+  if (diagnostic_sensor_ == nullptr)
+    return;
+
+  // Build this line at publication time instead of adding it to the event
+  // history. Presence refreshes and expiry therefore replace the old snapshot
+  // without manufacturing diagnostic events.
+  std::string state = diagnostic_history_;
+  if (!state.empty())
+    state += '\n';
+  state += remote_list_();
+  diagnostic_sensor_->publish_state(state);
 }
 
 const char *ToshibaAbClimate::protocol_name_(Protocol protocol) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -7,6 +7,7 @@
 #include "esphome/core/component.h"
 #include <array>
 #include <string>
+#include <vector>
 
 namespace esphome {
 namespace toshiba_ab {
@@ -75,6 +76,7 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   static constexpr uint32_t PROTOCOL_SCAN_MS = 20000;
   static constexpr uint32_t DISCOVERY_MS = 3 * PROTOCOL_SCAN_MS;
   static constexpr uint32_t BYTE_TIMEOUT_MS = 25;
+  static constexpr uint32_t REMOTE_EXPIRY_MS = 5 * 60 * 1000;
   static constexpr size_t MAX_FRAME_SIZE = 132;
   static constexpr ProtocolValue MASTER_KEEPALIVE_OPCODE{0x10, 0x00, 0x10};
   // Length is the value carried by each protocol's length byte, rather than
@@ -102,8 +104,12 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   bool is_master_keepalive_(Protocol protocol, const uint8_t *data, size_t size, uint8_t &source) const;
   bool is_remote_ping_(Protocol protocol, const uint8_t *data, size_t size, uint8_t &source) const;
   void consider_keepalive_(Protocol protocol, uint8_t source);
+  void observe_remote_(uint8_t address, uint32_t now);
+  void expire_remotes_(uint32_t now);
   void set_runtime_parity_(uart::UARTParityOptions parity);
   void diagnostic_(const std::string &message);
+  void publish_diagnostic_();
+  std::string remote_list_() const;
   static const char *protocol_name_(Protocol protocol);
   static uint8_t opcode_(Protocol protocol, const uint8_t *data, size_t size);
   static uint8_t frame_length_(Protocol protocol, const uint8_t *data, size_t size);
@@ -125,6 +131,11 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   uint32_t boot_ms_{0};
   uint32_t last_byte_ms_{0};
   uint32_t reader_reset_count_{0};
+  struct RemotePresence {
+    uint8_t address;
+    uint32_t last_seen;
+  };
+  std::vector<RemotePresence> remotes_;
   std::string diagnostic_history_;
   text_sensor::TextSensor *diagnostic_sensor_{nullptr};
   uint8_t hardware_uart_rx_pin_{0xFF};

--- a/docs/new_code_progress.md
+++ b/docs/new_code_progress.md
@@ -42,7 +42,7 @@ Status meanings:
 | Automatic protocol discovery | Done | Scans TCC, A0, and TU2C for 20 seconds each and confirms a protocol only from a checksum-valid master keepalive. |
 | Runtime UART parity selection | Partial | Selects even parity for TCC/A0 and no parity for TU2C. Includes the existing ESP8266 UART0 GPIO13 swap path; broader hardware validation is still required. |
 | Master-address discovery and validation | Done | Learns the source from the first valid master keepalive or checks it against an explicitly configured address. |
-| Existing remote discovery | Partial | After protocol and master confirmation, labels known checksum-valid remote ping signatures in the normal frame log. Address assignment and a persistent inventory are not implemented yet. |
+| Existing remote discovery | Partial | After protocol and master confirmation, known checksum-valid remote pings maintain a live address inventory. Addresses expire after five minutes without a ping; ESP address assignment is not implemented yet. |
 | Frame logging | Done | Logs every complete candidate, highlights addresses and command/type fields, and marks checksum failures. |
 | Diagnostic history | Done | Publishes a newline-separated, de-duplicated event history capped at 255 characters. |
 | Manual rediscovery | Done | The diagnostic reset button clears discovery state, reader state, counters, and history, then restarts scanning. |
@@ -151,10 +151,13 @@ logging pipeline identifies these existing remote-controller pings:
 | A0 demand interface | Length `0x0C`, opcode `0x55`, data type `00:9F` | `remote ping 0xNN` |
 
 All of these frames are addressed to the master. Classification therefore
-requires that the frame destination equal the confirmed master address. At
-this stage presence is deliberately observable only through
-the existing debug frame log; addresses are not stored and do not yet influence
-the configured ESP address. As with master keepalive identification, encoded
+requires that the frame destination equal the confirmed master address. The
+diagnostic sensor always ends with a `Current remotes:` snapshot. A valid ping
+adds or refreshes its source address, and an address is removed after five
+minutes without another ping. The snapshot is replaced in place rather than
+added to diagnostic history, so routine presence changes do not displace useful
+discovery events. The addresses do not yet influence the configured ESP
+address. As with master keepalive identification, encoded
 lengths, opcodes, and data types are held in protocol-value constants and
 compared through the common semantic field helpers rather than at raw offsets.
 


### PR DESCRIPTION
### Motivation

- Provide a live, in-memory inventory of currently-seen remotes so presence can be used later for address assignment, with entries expiring after five minutes and without flooding the diagnostic event history.

### Description

- Add `REMOTE_EXPIRY_MS`, a `RemotePresence` struct and a `remotes_` vector to `ToshibaAbClimate` to store observed remote addresses and last-seen timestamps.
- Call `observe_remote_` for validated remote pings to refresh existing entries or insert new ones, keep the list sorted, and call `publish_diagnostic_` when the set changes.
- Run `expire_remotes_` from `loop()` to remove entries older than `REMOTE_EXPIRY_MS` using unsigned subtraction so `millis()` wrap is safe. `reset()` also clears `remotes_` immediately.
- Publish a replaceable snapshot line appended to the diagnostic sensor via `publish_diagnostic_` (built from `diagnostic_history_` + `remote_list_()`), using `Current remotes: none` when empty so presence updates do not create new history events; update `docs/new_code_progress.md` to document the behavior.

### Testing

- Ran `git diff --check` and code formatting; no issues reported. (success)
- Ran `python -m py_compile components/toshiba_ab/__init__.py components/toshiba_ab/climate.py`; compilation succeeded. (success)
- Validated configuration with `esphome config /tmp/toshiba-ab-test.yaml` using the local component; configuration parsed and reported valid. (success)
- Attempted `esphome compile /tmp/toshiba-ab-test.yaml`, but the PlatformIO dependency download failed with an `HTTPClientError` before firmware compilation could complete. (failed to finish)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9d4ebb24d4832fa207101a6fb0fe2b)