### PR TITLE
Improve TCC framing recovery and simplify diagnostic remote publishing

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -147,15 +147,31 @@ void ToshibaAbClimate::read_even_byte_(uint8_t byte) {
     return;
   }
 
-  // TCC has no sync marker. Keep a sliding candidate so a bad length or CRC
-  // cannot leave the reader permanently aligned to noise/a truncated frame.
-  if (tcc_size_ < tcc_.size())
-    tcc_[tcc_size_++] = byte;
-  else {
+  // TCC starts directly with source/destination bytes; unlike A0 and TU2C it
+  // has no reserved framing prefix that identifies a frame boundary. Keep a
+  // sliding candidate so a bad length or CRC cannot leave the reader
+  // permanently aligned to noise/a truncated frame.
+  if (tcc_size_ >= tcc_.size())
     reset_readers_();
-    tcc_[tcc_size_++] = byte;
+
+  // The first received byte is the source address. Values above 0xA0 are not
+  // valid TCC participants and are most likely line noise; discard the byte,
+  // reset the reader, and keep waiting for a valid source byte.
+  if (tcc_size_ == 0 && byte > 0xA0) {
+    reset_readers_();
+    reader_reset_count_++;
+    return;
   }
+  tcc_[tcc_size_++] = byte;
+
   while (tcc_size_ >= 4) {
+    // Recovery may have shifted a later byte into the source position. Apply
+    // the same rule there and abandon the candidate buffer completely.
+    if (tcc_[0] > 0xA0) {
+      reset_readers_();
+      reader_reset_count_++;
+      break;
+    }
     if (tcc_expected_ == 0)
       tcc_expected_ = static_cast<size_t>(tcc_[3]) + 5;
     if (tcc_[3] < 2 || tcc_expected_ > tcc_.size()) {
@@ -378,6 +394,11 @@ void ToshibaAbClimate::consider_keepalive_(Protocol protocol, uint8_t source) {
   }
   master_address_ = source;
   master_address_confirmed_ = true;
+  // The scan-start message describes a phase that has now ended. Keeping it
+  // in the published state made every later remote-list update look like it
+  // had restarted discovery, even though update_discovery_ is permanently
+  // disabled after protocol confirmation.
+  diagnostic_history_.clear();
   diagnostic_(std::string("Confirmed ") + protocol_name_(protocol) + " master " + hex_(&source, 1));
 }
 
@@ -392,19 +413,22 @@ void ToshibaAbClimate::observe_remote_(uint8_t address, uint32_t now) {
   remotes_.push_back({address, now});
   std::sort(remotes_.begin(), remotes_.end(),
             [](const RemotePresence &left, const RemotePresence &right) { return left.address < right.address; });
-  publish_diagnostic_();
+  diagnostic_(std::string("Remote discovered: ") + hex_(&address, 1));
 }
 
 void ToshibaAbClimate::expire_remotes_(uint32_t now) {
-  const size_t previous_size = remotes_.size();
+  std::vector<uint8_t> expired;
   remotes_.erase(std::remove_if(remotes_.begin(), remotes_.end(),
-                                [now](const RemotePresence &remote) {
+                                [now, &expired](const RemotePresence &remote) {
                                   // Unsigned subtraction keeps this correct when millis() wraps.
-                                  return now - remote.last_seen >= REMOTE_EXPIRY_MS;
+                                  if (now - remote.last_seen < REMOTE_EXPIRY_MS)
+                                    return false;
+                                  expired.push_back(remote.address);
+                                  return true;
                                 }),
                  remotes_.end());
-  if (remotes_.size() != previous_size)
-    publish_diagnostic_();
+  for (uint8_t address : expired)
+    diagnostic_(std::string("Remote removed: ") + hex_(&address, 1));
 }
 
 void ToshibaAbClimate::set_runtime_parity_(uart::UARTParityOptions parity) {
@@ -443,30 +467,8 @@ void ToshibaAbClimate::diagnostic_(const std::string &message) {
     }
     diagnostic_history_.erase(0, newline + 1);
   }
-  publish_diagnostic_();
-}
-
-std::string ToshibaAbClimate::remote_list_() const {
-  std::string list = "Current remotes:";
-  if (remotes_.empty())
-    return list + " none";
-  for (const auto &remote : remotes_)
-    list += " " + hex_(&remote.address, 1);
-  return list;
-}
-
-void ToshibaAbClimate::publish_diagnostic_() {
-  if (diagnostic_sensor_ == nullptr)
-    return;
-
-  // Build this line at publication time instead of adding it to the event
-  // history. Presence refreshes and expiry therefore replace the old snapshot
-  // without manufacturing diagnostic events.
-  std::string state = diagnostic_history_;
-  if (!state.empty())
-    state += '\n';
-  state += remote_list_();
-  diagnostic_sensor_->publish_state(state);
+  if (diagnostic_sensor_ != nullptr)
+    diagnostic_sensor_->publish_state(diagnostic_history_);
 }
 
 const char *ToshibaAbClimate::protocol_name_(Protocol protocol) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -108,8 +108,6 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   void expire_remotes_(uint32_t now);
   void set_runtime_parity_(uart::UARTParityOptions parity);
   void diagnostic_(const std::string &message);
-  void publish_diagnostic_();
-  std::string remote_list_() const;
   static const char *protocol_name_(Protocol protocol);
   static uint8_t opcode_(Protocol protocol, const uint8_t *data, size_t size);
   static uint8_t frame_length_(Protocol protocol, const uint8_t *data, size_t size);

--- a/docs/new_code_progress.md
+++ b/docs/new_code_progress.md
@@ -89,15 +89,30 @@ and then drains all currently available UART bytes into the active reader.
 
 #### TCC
 
-TCC has no start marker, so the reader maintains a sliding candidate buffer.
-Once four bytes are available, byte 3 gives the payload length and the expected
-complete buffer size is `length + 5`. The length must be at least 2 and the
-complete frame must fit in the 132-byte buffer. The final byte is compared with
-the XOR of all prior frame bytes.
+TCC begins immediately with `SRC:DST:OPCODE:LEN`; it has no reserved byte or
+byte sequence whose only framing purpose is to announce "a frame starts here."
+In other words, source address `0x40` in a captured frame is data, not a sync
+marker, and another `0x40` could legally occur elsewhere in a frame. The reader
+therefore cannot jump directly to a known boundary after corruption and instead
+maintains a sliding candidate buffer. Once four bytes are available, byte 3
+gives the payload length and the expected complete buffer size is `length + 5`.
+The length must be at least 2 and the complete frame must fit in the 132-byte
+buffer. The final byte is compared with the XOR of all prior frame bytes.
 
 - Valid candidate: process it and remove the complete frame from the buffer.
 - Invalid length or checksum: discard only the oldest byte, increment the
   resynchronization count, and evaluate the shifted candidate.
+
+When the reader is waiting for the first byte of a new frame, that byte is the
+source address. A value above `0xA0` cannot identify a valid TCC participant and
+is treated as probable line noise: the byte is discarded immediately, reader
+state is reset, and collection remains at the source-byte position. The filter
+therefore does not wait for the rest of a noise-derived candidate, and it does
+not reject values above `0xA0` while they occupy payload positions in a frame
+whose source was already accepted. If checksum recovery shifts a byte into the
+source position and that byte is invalid, the accumulated candidate buffer is
+reset by the same rule. The filter applies both during automatic TCC discovery
+and while TCC is explicitly selected.
 
 Discarding one byte rather than the entire buffer allows the reader to recover
 when noise or a truncated frame appears immediately before a valid frame.
@@ -108,14 +123,25 @@ The A0 reader waits for the unambiguous `A0:00` wrapper. Byte 3 contains the bod
 length, making the complete size `length + 6` (wrapper, type, length, body, and
 two CRC bytes). Sizes below 8 or above 132 are rejected. The last two bytes are
 read as a big-endian received CRC and compared with CRC-16/MCRF4XX calculated
-over every preceding byte.
+over every preceding byte. After either a valid or checksum-invalid complete
+candidate, the reader discards that whole candidate and waits for the next
+`A0:00` wrapper; it does not reinterpret each overlapping suffix as a frame.
 
 #### TU2C
 
 The TU2C reader waits for `F0:F0`. Byte 2 contains the total frame size,
 including both `F0` bytes and the final `A0`. A valid size is 7–132 bytes. The
 penultimate byte must equal the 8-bit sum of bytes from the length byte through
-the byte before the checksum, and the last byte must be `A0`.
+the byte before the checksum, and the last byte must be `A0`. As with A0, after
+a complete candidate the reader resets to searching for the next `F0:F0`
+prefix rather than sliding one byte at a time through the failed candidate.
+
+Consequently, the deterministic cascade seen in the TCC log cannot be produced
+by the A0 or TU2C recovery paths: one checksum-invalid candidate produces one
+failure report. Multiple failures are still possible when multiple frames are
+actually damaged, or when corrupted/noisy input contains another apparent
+wrapper and forms a second complete candidate. Those are distinct candidates,
+not the overlapping suffixes responsible for the TCC cascade.
 
 For every protocol, a partial wrapper or frame is discarded if no next byte is
 received for more than 25 ms. Switching scan protocols also resets every reader
@@ -152,12 +178,12 @@ logging pipeline identifies these existing remote-controller pings:
 
 All of these frames are addressed to the master. Classification therefore
 requires that the frame destination equal the confirmed master address. The
-diagnostic sensor always ends with a `Current remotes:` snapshot. A valid ping
-adds or refreshes its source address, and an address is removed after five
-minutes without another ping. The snapshot is replaced in place rather than
-added to diagnostic history, so routine presence changes do not displace useful
-discovery events. The addresses do not yet influence the configured ESP
-address. As with master keepalive identification, encoded
+component keeps a live remote-address inventory internally. A valid ping adds
+or refreshes its source address, and an address is removed after five minutes
+without another ping. The diagnostic history records `Remote discovered:` and
+`Remote removed:` events only when membership changes; routine presence
+refreshes do not republish a current-address snapshot. The addresses do not yet
+influence the configured ESP address. As with master keepalive identification, encoded
 lengths, opcodes, and data types are held in protocol-value constants and
 compared through the common semantic field helpers rather than at raw offsets.
 


### PR DESCRIPTION
### Motivation
- Make the TCC reader more robust to line noise by rejecting impossible source addresses early and preventing long-lived misalignment. 
- Reduce noisy/duplicated diagnostic output and keep discovery events separate from the ongoing remote-presence snapshot. 
- Simplify diagnostic publishing by removing the on-demand snapshot builder and emitting concise discovery/expiry events.

### Description
- Strengthen the TCC framing logic in `read_even_byte_` by rejecting a candidate immediately when the first/source byte is greater than `0xA0`, resetting the reader, and incrementing `reader_reset_count_`, and by resetting the reader when the candidate buffer would overflow. 
- Ensure the same source-byte validation is applied when recovery shifts bytes into the source position to avoid evaluating invalid candidates. 
- Clear `diagnostic_history_` in `consider_keepalive_` when discovery completes so the initial scan-start message does not persist and confuse later updates. 
- Replace `publish_diagnostic_` and `remote_list_` with direct calls to `diagnostic_` to emit `Remote discovered:` and `Remote removed:` messages on membership changes, and change `diagnostic_` to publish the trimmed history directly to the diagnostic sensor when available. 
- Change `expire_remotes_` to collect expired addresses and emit a `Remote removed:` diagnostic per expired address instead of republishing a snapshot string. 
- Update documentation (`docs/new_code_progress.md`) to reflect the TCC source-byte rule, the non-sliding behavior for A0/TU2C after a candidate, and the new diagnostic behavior.

### Testing
- Built the project with `pio run` and verified a successful compilation. 
- Ran the test suite (`pio test`) and confirmed all automated tests passed. 
- Verified no regressions in diagnostic publish calls via CI lint/build checks which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9d52593138832fa92685bae5d331bf)