### PR TITLE
Log protocol confirmation only once

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -376,6 +376,13 @@ bool ToshibaAbClimate::is_remote_ping_(Protocol protocol, const uint8_t *data, s
 }
 
 void ToshibaAbClimate::consider_keepalive_(Protocol protocol, uint8_t source) {
+  // Keepalives continue for the lifetime of the bus, but confirmation is a
+  // discovery transition rather than a periodic event. In particular, do not
+  // clear and rebuild the diagnostic history for every keepalive after both
+  // the protocol and master have already been confirmed.
+  if (protocol_confirmed_ && master_address_confirmed_)
+    return;
+
   if (protocol_setting_ != Protocol::AUTO && protocol_setting_ != protocol) {
     diagnostic_(std::string("Detected ") + protocol_name_(protocol) + " but YAML format is " +
                 protocol_name_(protocol_setting_));


### PR DESCRIPTION
### Motivation
- Repeated master keepalives after discovery were causing the component to clear diagnostic history and republish the protocol/master confirmation repeatedly instead of treating confirmation as a one-time discovery transition.

### Description
- Add an early return in `ToshibaAbClimate::consider_keepalive_` to skip processing when both `protocol_confirmed_` and `master_address_confirmed_` are true, preventing repeated clearing of `diagnostic_history_` and duplicate confirmation logs (changed `components/toshiba_ab/toshiba_ab.cpp`).

### Testing
- Ran `git diff --check` which passed.  
- Ran `clang-format --dry-run --Werror` on `components/toshiba_ab/toshiba_ab.cpp` and `components/toshiba_ab/toshiba_ab.h` which passed.  
- Verified the change was staged and committed locally (`Log protocol confirmation only once`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9ddc4d02fc832f8edf5515b5073d48)