### PR TITLE
Simplify diagnostic sensor state

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -81,7 +81,6 @@ void ToshibaAbClimate::reset() {
   discovery_finished_ = false;
   reader_reset_count_ = 0;
   remotes_.clear();
-  diagnostic_history_.clear();
   select_scan_protocol_(protocol_setting_ == Protocol::AUTO ? Protocol::TCC : protocol_setting_);
   diagnostic_(protocol_setting_ == Protocol::AUTO
                   ? "Reset: scanning TCC master keepalives (0-20s)"
@@ -377,9 +376,7 @@ bool ToshibaAbClimate::is_remote_ping_(Protocol protocol, const uint8_t *data, s
 
 void ToshibaAbClimate::consider_keepalive_(Protocol protocol, uint8_t source) {
   // Keepalives continue for the lifetime of the bus, but confirmation is a
-  // discovery transition rather than a periodic event. In particular, do not
-  // clear and rebuild the diagnostic history for every keepalive after both
-  // the protocol and master have already been confirmed.
+  // discovery transition rather than a periodic event.
   if (protocol_confirmed_ && master_address_confirmed_)
     return;
 
@@ -401,11 +398,6 @@ void ToshibaAbClimate::consider_keepalive_(Protocol protocol, uint8_t source) {
   }
   master_address_ = source;
   master_address_confirmed_ = true;
-  // The scan-start message describes a phase that has now ended. Keeping it
-  // in the published state made every later remote-list update look like it
-  // had restarted discovery, even though update_discovery_ is permanently
-  // disabled after protocol confirmation.
-  diagnostic_history_.clear();
   diagnostic_(std::string("Confirmed ") + protocol_name_(protocol) + " master " + hex_(&source, 1));
 }
 
@@ -453,29 +445,9 @@ void ToshibaAbClimate::set_runtime_parity_(uart::UARTParityOptions parity) {
 }
 
 void ToshibaAbClimate::diagnostic_(const std::string &message) {
-  // The diagnostic sensor contains a short event history. Periodic frames can
-  // produce the same event repeatedly, but consecutive copies carry no extra
-  // information and would crowd useful discovery messages out of the sensor.
-  const size_t last_message = diagnostic_history_.find_last_of('\n');
-  const size_t last_message_start = last_message == std::string::npos ? 0 : last_message + 1;
-  if (!diagnostic_history_.empty() && diagnostic_history_.size() - last_message_start == message.size() &&
-      diagnostic_history_.compare(last_message_start, message.size(), message) == 0)
-    return;
-
   ESP_LOGI(TAG, "%s", message.c_str());
-  if (!diagnostic_history_.empty())
-    diagnostic_history_ += '\n';
-  diagnostic_history_ += message;
-  while (diagnostic_history_.size() > 255) {
-    const size_t newline = diagnostic_history_.find('\n');
-    if (newline == std::string::npos) {
-      diagnostic_history_.erase(0, diagnostic_history_.size() - 255);
-      break;
-    }
-    diagnostic_history_.erase(0, newline + 1);
-  }
   if (diagnostic_sensor_ != nullptr)
-    diagnostic_sensor_->publish_state(diagnostic_history_);
+    diagnostic_sensor_->publish_state(message);
 }
 
 const char *ToshibaAbClimate::protocol_name_(Protocol protocol) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -134,7 +134,6 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
     uint32_t last_seen;
   };
   std::vector<RemotePresence> remotes_;
-  std::string diagnostic_history_;
   text_sensor::TextSensor *diagnostic_sensor_{nullptr};
   uint8_t hardware_uart_rx_pin_{0xFF};
 

--- a/docs/new_code_progress.md
+++ b/docs/new_code_progress.md
@@ -44,8 +44,8 @@ Status meanings:
 | Master-address discovery and validation | Done | Learns the source from the first valid master keepalive or checks it against an explicitly configured address. |
 | Existing remote discovery | Partial | After protocol and master confirmation, known checksum-valid remote pings maintain a live address inventory. Addresses expire after five minutes without a ping; ESP address assignment is not implemented yet. |
 | Frame logging | Done | Logs every complete candidate, highlights addresses and command/type fields, and marks checksum failures. |
-| Diagnostic history | Done | Publishes a newline-separated, de-duplicated event history capped at 255 characters. |
-| Manual rediscovery | Done | The diagnostic reset button clears discovery state, reader state, counters, and history, then restarts scanning. |
+| Diagnostic sensor | Done | Publishes the latest discovery event; earlier states remain available through Home Assistant history. |
+| Manual rediscovery | Done | The diagnostic reset button clears discovery state, reader state, and counters, then restarts scanning. |
 | Climate API capability declaration | Partial | Air systems advertise the intended climate modes, fan modes, swing modes, presets, current temperature, and action. Water systems currently expose only off mode. These are API declarations, not working controls. |
 | Climate state decoding | Not started | Valid non-keepalive frames are logged and then discarded. State parsing and publication must be rebuilt. |
 | Command generation/transmission | Not started | `control()` deliberately ignores calls. Address assignment, command queues, retries, and bus timing still need implementation. |
@@ -64,7 +64,7 @@ that protocol is selected.
 
 The reset button calls the same discovery initialization intentionally, with
 additional cleanup: protocol/master confirmation flags, frame-reader buffers,
-the resynchronization counter, and diagnostic history are cleared.
+and the resynchronization counter are cleared.
 
 ### 2. Protocol scan schedule
 
@@ -180,7 +180,7 @@ All of these frames are addressed to the master. Classification therefore
 requires that the frame destination equal the confirmed master address. The
 component keeps a live remote-address inventory internally. A valid ping adds
 or refreshes its source address, and an address is removed after five minutes
-without another ping. The diagnostic history records `Remote discovered:` and
+without another ping. The diagnostic sensor reports `Remote discovered:` and
 `Remote removed:` events only when membership changes; routine presence
 refreshes do not republish a current-address snapshot. The addresses do not yet
 influence the configured ESP address. As with master keepalive identification, encoded
@@ -229,7 +229,7 @@ These capabilities must not be interpreted as functional support yet:
 | `zone_2` | `false` | Create a second heating/cooling thermostat when enabled. |
 | `master_address` | `auto` (`0xAA` internally) | Learn the master or require an explicit 8-bit address. |
 | `esp_address` | `auto` (`0xAA` internally) | Stores the future local address; it is not yet used to transmit. |
-| `diagnostic` | `Toshiba AB Diagnostic` | Text sensor containing recent discovery events. |
+| `diagnostic` | `Toshiba AB Diagnostic` | Text sensor containing the latest discovery event. |
 | `reset_button` | `Toshiba AB Reset` | Restarts the identification process without rebooting. |
 
 The UART validator requires 2400 baud. It normally requires an RX pin; on


### PR DESCRIPTION
### Motivation
- The diagnostic text sensor should show only the latest relevant discovery message rather than maintaining an internal newline-separated 255-character history because Home Assistant already stores historical states.
- Removing the in-component history reduces memory and complexity and avoids repeated de-duplication/truncation logic.
- Update the documentation to reflect the simpler sensor behaviour.

### Description
- Removed the `diagnostic_history_` member from `ToshibaAbClimate` and eliminated all append/truncate/deduplication logic in `diagnostic_`.
- `ToshibaAbClimate::diagnostic_(const std::string &message)` now logs via `ESP_LOGI` and directly publishes the given `message` with `diagnostic_sensor_->publish_state(message)`.
- Removed calls that cleared the old history during `reset()` and when confirming the protocol/master, since there is no longer any stored history to manage.
- Updated `docs/new_code_progress.md` to state that the diagnostic text sensor publishes the latest discovery event and that earlier states are available through Home Assistant history.

### Testing
- Ran `python -m compileall -q components` and compilation checks completed successfully.
- Ran `clang-format --dry-run --Werror components/toshiba_ab/toshiba_ab.cpp components/toshiba_ab/toshiba_ab.h` and the style check passed.
- Ran `git diff --check` and no whitespace or basic diff issues were reported.
- Ran the repository `./format.sh` which referenced a removed `components/tcc_link` clang-format target, so validation was instead performed with the targeted `clang-format` command above (informational warning, not a functional test failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9dde532d90832fb3177ff8db52c21a)