### PR TITLE
Fix A0 remote ping decoding and use `opcode` terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ use a 2400 baud, 8N1 UART (`parity: NONE`). See the
 ### May 2026 — ESTIA R32 and protocol improvements
 
 Thanks to [@7tobias](https://github.com/7tobias), Toshiba R32 ESTIA Series 1
-systems are supported. The component can detect the normal TCC-Link, HM and
-ESTIA R32/A0 formats, and address assignment avoids duplicate-address E09
-errors. Thanks to [@mtthidoteu](https://github.com/mtthidoteu), HM-format support
-and hardware UART operation improve compatibility and stability.
+systems are supported. The component can detect the normal TCC-Link, TU2C and
+A0 formats—the A0 format is shared by HM air systems and ESTIA R32—and address
+assignment avoids duplicate-address E09 errors. Thanks to
+[@mtthidoteu](https://github.com/mtthidoteu), HM-system support and hardware UART
+operation improve compatibility and stability.
 
 ### January 2026 — autonomous mode
 

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -133,7 +133,7 @@ void ToshibaAbClimate::read_even_byte_(uint8_t byte) {
       if (a0_size_ < a0_.size())
         a0_[a0_size_++] = byte;
       if (a0_size_ == 4) {
-        a0_expected_ = static_cast<size_t>(a0_[3]) + 6;  // wrapper, type, length, body, CRC16
+        a0_expected_ = static_cast<size_t>(a0_[3]) + 6;  // wrapper, opcode, length, body, CRC16
         if (a0_expected_ < 8 || a0_expected_ > a0_.size())
           a0_size_ = a0_expected_ = 0;
       }
@@ -321,8 +321,8 @@ bool ToshibaAbClimate::is_master_keepalive_(Protocol protocol, const uint8_t *da
       source = size > 3 ? data[3] : 0;
       break;
     case Protocol::A0:
-      // A0 water and air units use the same type 0x10 keepalive.
-      // Wire layout is A0:00:TYPE:LEN:00:SRC_MODE:SRC:DST_MODE:DST:...
+      // A0 water and air units use the same opcode 0x10 keepalive.
+      // Wire layout is A0:00:OPCODE:LEN:00:SRC_MODE:SRC:DST_MODE:DST:...
       source = size > 6 ? data[6] : 0;
       break;
     default:

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -86,9 +86,9 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   // and 0x3A is the data type. A0 master heartbeats carry the two-byte data
   // type 00:8A in the corresponding field.
   static constexpr ProtocolValue MASTER_KEEPALIVE_DATA_TYPE{0x8A, 0x3A, 0x008A};
-  static constexpr ProtocolValue REMOTE_PING_OPCODE{0x15, 0x41, 0x55};
+  static constexpr ProtocolValue REMOTE_PING_OPCODE{0x15, 0x41, 0x15};
   static constexpr ProtocolValue REMOTE_PING_LENGTH{0x07, 0x0C, 0x0C};
-  static constexpr ProtocolValue REMOTE_PING_DATA_TYPE{0x0C, 0x5C, 0x009F};
+  static constexpr ProtocolValue REMOTE_PING_DATA_TYPE{0x0C, 0x5C, 0x0C81};
   // First-generation Estia shares the TU2C wire format but uses data type
   // 0x0C for its remote ping instead of the air protocol's 0x5C.
   static constexpr uint16_t TU2C_FIRST_GEN_REMOTE_PING_DATA_TYPE = 0x0C;

--- a/docs/frame_formats.md
+++ b/docs/frame_formats.md
@@ -3,7 +3,8 @@
 This document describes the three wire protocols understood by the current
 component: **TCC**, **TU2C**, and **A0**. `system_type` (`air` or `water`) is not
 a fourth protocol: it describes the equipment using a protocol. In particular,
-first-generation ESTIA water systems use TU2C, while newer ESTIA systems use A0.
+first-generation ESTIA water systems use TU2C, while newer ESTIA systems and
+HM-range air systems use A0.
 
 The implementation is currently identification-only. It collects and checks all
 frames, but identifies only the two frame types documented below: **master
@@ -50,7 +51,7 @@ parity).
 
 ```text
 byte        0    1     2      3    4      5       6      7       8       9        10    ...  N+4  N+5
-field      A0   00   TYPE    LEN   00  SRC_MODE  SRC  DST_MODE  DST  DTYPE_H  DTYPE_L DATA CRC_H CRC_L
+field      A0   00  OPCODE   LEN   00  SRC_MODE  SRC  DST_MODE  DST  DTYPE_H  DTYPE_L DATA CRC_H CRC_L
 ```
 
 The complete frame is `N + 6` bytes. `LEN` counts the bytes after itself and
@@ -96,7 +97,7 @@ the classifier does not restrict a valid remote ping to these ranges.
 | TU2C | `air` | `0x50` | Conventional U-series remote. Additional controllers may occupy nearby addresses. |
 | TU2C | `water` | `0x60`–`0x69` | First-generation ESTIA supports up to ten remote addresses; `0x60` is the usual first remote. |
 | A0 | `air` | `0x40` | Conventional remote, normally represented by the low source byte. |
-| A0 | `water` | `0x40`; `0x41` for the optional demand interface | The currently identified A0 remote-ping signature is the `0x41` 0–10 V demand-interface ping. |
+| A0 | `water` | `0x40` | Conventional remote, using the same A0 remote-ping signature as air systems. |
 
 The ESP's `esp_address` setting also defaults to automatic. Remote discovery
 currently maintains a presence list only; it does not yet select or change the
@@ -112,11 +113,11 @@ is the conjunction of all columns below, not merely an opcode match.
 The first valid master keepalive confirms the protocol and supplies the master
 source address. Air and water use the same signature within each wire protocol.
 
-| Protocol | `system_type` | Encoded length | Opcode/type | Data type | Field-level signature |
+| Protocol | `system_type` | Encoded length | Opcode | Data type | Field-level signature |
 | --- | --- | ---: | ---: | ---: | --- |
 | TCC | `air`, `water` | `0x02` | `OPCODE = 0x10` | `DATA[1] = 0x8A` | `SRC:*:10:02:*:8A:CRC` |
 | TU2C | `air`, `water` | `TOTAL_LEN = 0x0A` | byte 6 `OPCODE = 0x00` | byte 7 `DTYPE = 0x3A` | `F0:F0:0A:SRC:DST:*:00:3A:SUM:A0` |
-| A0 | `air`, `water` | `LEN = 0x07` | `TYPE = 0x10` | `DTYPE = 00:8A` | `A0:00:10:07:00:SRC_MODE:SRC:DST_MODE:DST:00:8A:CRC16` |
+| A0 | `air`, `water` | `LEN = 0x07` | `OPCODE = 0x10` | `DTYPE = 00:8A` | `A0:00:10:07:00:SRC_MODE:SRC:DST_MODE:DST:00:8A:CRC16` |
 
 For TCC, the unspecified first data byte is still covered by the XOR. For TU2C,
 the family byte and destination are not used to distinguish air from water. For
@@ -128,14 +129,14 @@ though discovery records the low source byte.
 Every remote-ping signature additionally requires `DST` to equal the already
 confirmed master and `SRC` to differ from it.
 
-| Protocol | `system_type` | Encoded length | Opcode/type | Data type | Additional signature detail |
+| Protocol | `system_type` | Encoded length | Opcode | Data type | Additional signature detail |
 | --- | --- | ---: | ---: | ---: | --- |
 | TCC | `air` | `0x07` | `OPCODE = 0x15` | `DATA[1] = 0x0C` | Payload begins `08:0C:81`; canonical shape is `SRC:DST:15:07:08:0C:81:...:CRC`. |
 | TCC | `water` | `0x07` | `OPCODE = 0x15` | `DATA[1] = 0x0C` | The current classifier is system-type agnostic; no separate water signature is known. |
 | TU2C | `air` | `TOTAL_LEN = 0x0C` | byte 6 `OPCODE = 0x41` | byte 7 `DTYPE = 0x5C` | Common family byte `C0`: `F0:F0:0C:SRC:DST:C0:41:5C:...:SUM:A0`. |
 | TU2C | `water` | `TOTAL_LEN = 0x0C` | byte 6 `OPCODE = 0x41` | byte 7 `DTYPE = 0x0C` | First-generation ESTIA commonly uses family byte `E0`. |
-| A0 | `air` | `LEN = 0x0C` | `TYPE = 0x55` | `DTYPE = 00:9F` | The current classifier is system-type agnostic; this is primarily the demand-interface signature. |
-| A0 | `water` | `LEN = 0x0C` | `TYPE = 0x55` | `DTYPE = 00:9F` | Identified for the ESTIA 0–10 V demand interface, normally source `0x41`. |
+| A0 | `air` | `LEN = 0x0C` | `OPCODE = 0x15` | `DTYPE = 0C:81` | Air and water use the same remote-ping signature. |
+| A0 | `water` | `LEN = 0x0C` | `OPCODE = 0x15` | `DTYPE = 0C:81` | Air and water use the same remote-ping signature. |
 
 The TCC implementation's decisive comparison is length/opcode/data type; the
 longer `08:0C:81` prefix shown in the table is the canonical observed ping. The
@@ -219,17 +220,15 @@ F0:F0:0C:60:70:E0:41:0C:90:F3:8C:A0
 Remote `0x60` pings master `0x70`; the water-specific data type is `0x0C` and
 `8C` is the additive checksum.
 
-#### A0 — water demand interface (also accepted for A0 air)
+#### A0 — air and water
 
 ```text
-A0:00:55:0C:00:00:41:08:00:00:9F:00:00:00:00:00:64:78
+A0:00:15:0C:00:00:40:08:00:00:0C:81:00:00:48:00:49:E8
 ```
 
-The demand interface source low byte is `0x41`, the master destination is
-encoded as `08:00`, and the type/data-type signature is `55` / `00:9F`.
-`64:78` is the CRC-16. Because the current A0 classifier does not branch on
-`system_type`, the same complete example is also recognized for an A0 air
-configuration.
+Remote `0x40` pings master `0x00`, encoded as `08:00`, with opcode `0x15` and
+data type `0C:81`. `49:E8` is the CRC-16. Air and water use this same remote-ping
+signature.
 
 ## Configuration names
 

--- a/docs/new_code_progress.md
+++ b/docs/new_code_progress.md
@@ -120,7 +120,7 @@ when noise or a truncated frame appears immediately before a valid frame.
 #### A0
 
 The A0 reader waits for the unambiguous `A0:00` wrapper. Byte 3 contains the body
-length, making the complete size `length + 6` (wrapper, type, length, body, and
+length, making the complete size `length + 6` (wrapper, opcode, length, body, and
 two CRC bytes). Sizes below 8 or above 132 are rejected. The last two bytes are
 read as a big-endian received CRC and compared with CRC-16/MCRF4XX calculated
 over every preceding byte. After either a valid or checksum-invalid complete
@@ -174,7 +174,7 @@ logging pipeline identifies these existing remote-controller pings:
 | TCC | Length `0x07`, opcode `0x15`, payload prefix `08:0C:81` | `remote ping 0xNN` |
 | TU2C air | Length `0x0C`, payload prefix `41:5C` | `remote ping 0xNN` |
 | TU2C first-generation Estia | Length `0x0C`, payload prefix `E0:41:0C` | `remote ping 0xNN` |
-| A0 demand interface | Length `0x0C`, opcode `0x55`, data type `00:9F` | `remote ping 0xNN` |
+| A0 air and water | Length `0x0C`, opcode `0x15`, data type `0C:81` | `remote ping 0xNN` |
 
 All of these frames are addressed to the master. Classification therefore
 requires that the frame destination equal the confirmed master address. The


### PR DESCRIPTION
### Motivation
- The A0 remote-ping signature was misidentified and must decode as opcode `0x15`, length `0x0C`, and data type bytes `0C:81` for both air and water (HM systems share the A0 wire format). 
- Protocol documentation used the term `type` for the A0 command field inconsistently with other protocols; unify the wire-field name to `opcode` throughout.

### Description
- Updated protocol constants in `components/toshiba_ab/toshiba_ab.h` to set A0 remote-ping opcode to `0x15` and A0 remote-ping data type to `0C:81` (`REMOTE_PING_OPCODE{0x15,0x41,0x15}` and `REMOTE_PING_DATA_TYPE{0x0C,0x5C,0x0C81}`).
- Clarified A0 frame parsing/comment in `components/toshiba_ab/toshiba_ab.cpp` (use `opcode` wording and adjust comment on expected size calculation to reference `opcode`).
- Updated the documentation to use `OPCODE` consistently and replaced the incorrect A0 demand-interface example with a checksum-valid A0 remote-ping example (`A0:00:15:0C:...:0C:81:...`) in `docs/frame_formats.md`, `docs/new_code_progress.md`, and `README.md` (note that HM air systems and ESTIA R32 use the A0 format).
- Committed the changes together as "Fix A0 remote ping signature".

### Testing
- Ran `clang-format --dry-run --Werror components/toshiba_ab/toshiba_ab.cpp components/toshiba_ab/toshiba_ab.h` and it succeeded.
- Executed a Python assertion script that verified the updated protocol constants, the updated documentation rows, and validated the example A0 frame CRC using `CRC-16/MCRF4XX` (example frame CRC `0x49E8`), and all assertions passed.
- Ran `git diff --check` to confirm no whitespace/format issues and `git status` to verify the working branch; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9df4a0cb90832f981bd91609478c57)